### PR TITLE
fix: use super().__init__() in TableWidget to fix PySide6 TypeError

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: Unix
     Operating System :: Microsoft :: Windows
+    Operating System :: MacOS
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only

--- a/src/napari_czann_segment/dock_widget.py
+++ b/src/napari_czann_segment/dock_widget.py
@@ -68,7 +68,7 @@ class TableWidget(QWidget):
         Returns:
         None
         """
-        super(QWidget, self).__init__()
+        super().__init__()
 
         self.layout = QVBoxLayout(self)
         self.model_table = QTableWidget()


### PR DESCRIPTION
## Problem

Opening the "Segment or Process with CZANN Model" dock widget in napari raises:

```
TypeError: libshiboken: PySide6.QtCore.QObject isn't a direct base class of TableWidget
```

The error occurs in `TableWidget.__init__` at:
```python
super(QWidget, self).__init__()
```

`super(QWidget, self)` resolves to the MRO entry *after* `QWidget`, not `QWidget` itself. PySide6/shiboken requires that Qt objects are properly initialized through their own `__init__`, so skipping it causes the TypeError.

## Fix

Replace with the idiomatic Python 3 call:
```python
super().__init__()
```

This correctly calls `QWidget.__init__` and satisfies PySide6's initialization requirements.